### PR TITLE
Publish only the necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.7.0",
         "graphql": "^14.5.4"
-    }
+    },
+    "files": [
+        "lib"
+    ]
 }


### PR DESCRIPTION
It's best to only publish to npm the files that are necessary, npm automatically includes package.json, README.md and LICENSE so I believe the only other thing your bundle requires is the `lib` folder.

Here's what's currently published:

https://unpkg.com/browse/graphql-codegen-persisted-query-ids@0.0.8/

You can see the result of this by running `yarn pack` or `npm pack` and looking at the contents of the resulting tgz.

(I prefer this "allow-list" approach to the "block-list" approach that `.npmignore` would give you.)

Relevant docs: https://docs.npmjs.com/files/package.json#files