### PR TITLE
Allow changing hash algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ generates:
     persisted-query-ids/client.json:
         - graphql-codegen-persisted-query-ids:
               output: client
+              algorithm: sha256
 
     persisted-query-ids/server.json:
         - graphql-codegen-persisted-query-ids:
               output: server
+              algorithm: sha256
 ```
 
 Run the generator

--- a/__tests__/codegen.test.ts
+++ b/__tests__/codegen.test.ts
@@ -1,4 +1,4 @@
-import { parse, DocumentNode } from "graphql";
+import { parse } from "graphql";
 import {
     generateQueryIds,
     findUsedFragments,
@@ -269,7 +269,7 @@ describe("can extract variable info", () => {
     `);
 
     test("does not use variables", async () => {
-        const client = generateQueryIds([doc1]);
+        const client = generateQueryIds([doc1], { output: "client" });
 
         expect(client["Foo"]).toMatchObject({
             hash: expect.stringMatching(/.+/),
@@ -279,7 +279,7 @@ describe("can extract variable info", () => {
     });
 
     test("does use variables", async () => {
-        const client = generateQueryIds([doc2]);
+        const client = generateQueryIds([doc2], { output: "client" });
 
         expect(client["Foo"]).toMatchObject({
             hash: expect.stringMatching(/.+/),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "typescript": "^3.6.3"
     },
     "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.7.0",
+        "@graphql-codegen/plugin-helpers": "1.7.x",
         "graphql": "^14.5.4"
     }
 }


### PR DESCRIPTION
We'd like to result in the same hashes as our previous hashing solution which uses SHA1. SHA256 is stronger than SHA1, but we're not (at all) worried about the risk of hash collisions since we control the queries.