### PR TITLE
Workaround breaking change in graphql-codegen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ export const plugin: PluginFunction<PluginConfig> = (
     config,
 ) => {
     const queries = generateQueryIds(
-        documents.map(doc => doc.content),
+        documents.map(doc => doc.content || doc.document),
         config,
     );
 


### PR DESCRIPTION
It seems that this property was renamed in a minor, leading to no persisted queries being exported. :disappointed: 