### PR TITLE
Updated README for Apollo Client v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ add_filter( 'graphql_lock_load_query', function( string $query, string $query_id
 Add custom `generateHash` to [apollo-link-persisted-queries](https://github.com/apollographql/apollo-link-persisted-queries)
 
 ```ts
-import { createPersistedQueryLink } from "apollo-link-persisted-queries";
+import { createPersistedQueryLink } from "@apollo/client/link/persisted-queries";
+// import {createPersistedQueryLink } from "apollo-link-persisted-queries"; // For Apollo Client v2
 import { usePregeneratedHashes } from "graphql-codegen-persisted-query-ids/lib/apollo";
 
 const hashes = require("../persisted-query-ids/client.json");


### PR DESCRIPTION
Took me a while to find out that "apollo-link-persisted-queries" is only supported for v2, and v3 had its own library. This update lists the import for both v2 and v3 so that new users can see the change for v3.